### PR TITLE
add dependency

### DIFF
--- a/src/install-wine.rst
+++ b/src/install-wine.rst
@@ -20,7 +20,7 @@ Install wine and winetricks
       The game may crash on Wine 7.0 or newer.
       It's recommended to use an older version.
 
-   Install ``wine`` following the `instructions on the Arch wiki <https://wiki.archlinux.org/index.php/Wine#Installation>`_.
+   Install ``wine`` following the `instructions on the Arch wiki <https://wiki.archlinux.org/index.php/Wine#Installation>`_. Also, install ``lib32-gnutls`` and ``gnutls``.
 
    Get the latest version of ``winetricks``:
 


### PR DESCRIPTION
When running the wa2 patch with wine 7.20-1 on Arch, users will not be able to download the patch's files from the server unless lib32-gnutls is installed. Wine will thrown an error about not being able to execute the transaction due to this missing dependency.